### PR TITLE
fix: restore e2e and codeql

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        uses: microsoft/playwright-github-action@v1
+        run: npx playwright install --with-deps
 
       - name: Build site
         run: npm run build --if-present || npx vite build

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
+        "@sentry/react": "^7.120.4",
+        "@sentry/replay": "^7.120.4",
         "gif-encoder-2": "^1.0.5",
         "highlight.js": "^11.11.1",
         "katex": "^0.16.22",
@@ -22,6 +24,7 @@
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.45.1",
         "@tailwindcss/postcss": "4.1.12",
         "@tailwindcss/vite": "4.1.12",
         "@types/react": "^18.3.4",
@@ -945,6 +948,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.34",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.34.tgz",
@@ -1231,6 +1250,151 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.4.tgz",
+      "integrity": "sha512-eSwgvTdrh03zYYaI6UVOjI9p4VmKg6+c2+CBQfRZX++6wwnCVsNv7XF7WUIpVGBAkJ0N2oapjQmCzJKGKBRWQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.4.tgz",
+      "integrity": "sha512-2+W4CgUL1VzrPjArbTid4WhKh7HH21vREVilZdvffQPVwOEpgNTPAb69loQuTlhJVveh9hWTj2nE5UXLbLP+AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.4.tgz",
+      "integrity": "sha512-ymlNtIPG6HAKzM/JXpWVGCzCNufZNADfy+O/olZuVJW5Be1DtOFyRnBvz0LeKbmxJbXb2lX/XMhuen6PXPdoQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.120.4",
+        "@sentry-internal/replay-canvas": "7.120.4",
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/replay": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.120.4.tgz",
+      "integrity": "sha512-Pj1MSezEncE+5riuwsk8peMncuz5HR72Yr1/RdZhMZvUxoxAR/tkwD3aPcK6ddQJTagd2TGwhdr9SHuDLtONew==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.4.tgz",
+      "integrity": "sha512-FW8sPenNFfnO/K7sncsSTX4rIVak9j7VUiLIagJrcqZIC7d1dInFNjy8CdVJUlyz3Y3TOgIl3L3+ZpjfyMnaZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.12",
@@ -2647,6 +2811,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2656,6 +2829,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
@@ -2869,6 +3048,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3129,6 +3317,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -4341,6 +4538,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -4546,6 +4790,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "react-router-dom": "^7.8.2",
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "@sentry/react": "^7.120.4",
+    "@sentry/replay": "^7.120.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.1.12",
@@ -32,6 +34,7 @@
     "postcss": "^8.4.41",
     "tailwindcss": "^4.1.12",
     "typescript": "^5.5.4",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "@playwright/test": "^1.45.1"
   }
 }

--- a/src/algorithms/sorting/selectionSort.ts
+++ b/src/algorithms/sorting/selectionSort.ts
@@ -1,10 +1,9 @@
 import type { Algorithm } from "@/engine/types";
 
-// Highlights keys match your colors: base, compared, swapped, pivot, highlighted
 // pcLine is 1-based, mapped to registry.codeLineMap for each language
 
-export const run: Algorithm = function* (input: number[]) {
-  const a = input.slice();
+export const run: Algorithm = function* (input: unknown) {
+  const a = (input as number[]).slice();
   const n = a.length;
 
   // Optional: initial frame
@@ -18,7 +17,7 @@ export const run: Algorithm = function* (input: number[]) {
       array: a.slice(),
       pcLine: 1,
       explain: `Pass ${i + 1}/${n - 1}: find the minimum in [${i}..${n - 1}]`,
-      highlights: { highlighted: [i], pivot: [m] },
+      highlights: { indices: [i], pivot: m },
     };
 
     for (let j = i + 1; j < n; j++) {
@@ -27,7 +26,7 @@ export const run: Algorithm = function* (input: number[]) {
         array: a.slice(),
         pcLine: 3,
         explain: `Compare a[${j}] (${a[j]}) with current min a[${m}] (${a[m]})`,
-        highlights: { highlighted: [i], pivot: [m], compared: [j] },
+        highlights: { indices: [i], pivot: m, compared: [j, m] },
       };
 
       if (a[j] < a[m]) {
@@ -37,7 +36,7 @@ export const run: Algorithm = function* (input: number[]) {
           array: a.slice(),
           pcLine: 4,
           explain: `New minimum at index ${m} (value ${a[m]})`,
-          highlights: { highlighted: [i], pivot: [m] },
+          highlights: { indices: [i], pivot: m },
         };
       }
     }
@@ -57,7 +56,7 @@ export const run: Algorithm = function* (input: number[]) {
         array: a.slice(),
         pcLine: 5,
         explain: `Position ${i} already holds the minimum; no swap.`,
-        highlights: { highlighted: [i], pivot: [m] },
+        highlights: { indices: [i], pivot: m },
       };
     }
   }

--- a/src/components/home/TopicSection.tsx
+++ b/src/components/home/TopicSection.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import AlgoTile from "./AlgoCard";
 import TopicIcon from "./TopicIcon";
 import type { AlgoMeta } from "@/algorithms/types";
@@ -5,6 +6,12 @@ import type { AlgoMeta } from "@/algorithms/types";
 type Props = { topic: string; items: AlgoMeta[] };
 
 export default function TopicSection({ topic, items }: Props) {
+  const titleMap = useMemo(() => {
+    const m: Record<string, { title: string; topic: string }> = {};
+    items.forEach((it) => (m[it.slug] = { title: it.title, topic }));
+    return m;
+  }, [items, topic]);
+
   return (
     <section className="mb-10">
       <div className="flex items-center gap-2 mb-3">
@@ -16,7 +23,7 @@ export default function TopicSection({ topic, items }: Props) {
       ) : (
         <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(220px,1fr))]">
           {items.map((a) => (
-            <AlgoTile key={a.slug} topic={topic} algo={a} />
+            <AlgoTile key={a.slug} topic={topic} item={a} titleMap={titleMap} />
           ))}
         </div>
       )}

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -20,7 +20,7 @@ export default function Markdown({ children }: { children: string }) {
           p: (p) => <p className="leading-7 mb-2" {...p} />,
           ul: (p) => <ul className="list-disc pl-5 space-y-1 mb-2" {...p} />,
           ol: (p) => <ol className="list-decimal pl-5 space-y-1 mb-2" {...p} />,
-          code: ({ inline, ...p }) =>
+          code: ({ inline, ...p }: { inline?: boolean } & React.HTMLAttributes<HTMLElement>) =>
             inline ? (
               <code
                 className="px-1 rounded bg-slate-100 dark:bg-slate-800"

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/types/gif-encoder-2.d.ts
+++ b/src/types/gif-encoder-2.d.ts
@@ -1,0 +1,1 @@
+declare module 'gif-encoder-2';


### PR DESCRIPTION
## Summary
- replace deprecated Playwright action with `npx playwright install --with-deps`
- add missing Sentry and Playwright packages and type declarations
- fix TypeScript issues in Markdown, TopicSection, and selection sort algorithm

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1bea9d474832e921b59e18a2f67fb