### PR TITLE
fix: ensure wait-on auto-installs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Start preview server
         run: |
           npx vite preview --port 4173 --strictPort &
-          npx wait-on http://127.0.0.1:4173
+          npx -y wait-on http://127.0.0.1:4173
 
       - name: Run Playwright tests
         env:


### PR DESCRIPTION
## Summary
- prevent `Start preview server` step from prompting for input by forcing `wait-on` to auto-install

## Testing
- `npm run build`
- `npx playwright test` *(fails: page.goto: net::ERR_ABORTED)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cb9df64c832eadaa03e2bfd991db