### PR TITLE
ci: fix Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,11 +27,7 @@ jobs:
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v12
         with:
-          # Option 1: run against local server
-          configPath: ''
+          configPath: lhci/lighthouserc.json
           runs: 1
           uploadArtifacts: true
           temporaryPublicStorage: true
-          startServerCommand: "npx http-server ./dist -p 4173 -s"
-          urls: |
-            http://127.0.0.1:4173/


### PR DESCRIPTION
## Summary
- use lighthouserc config for Lighthouse action and remove unsupported inputs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1cca56628832ea556b32029f85cc9