### PR TITLE
Fix manifest reference and improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     -->
 
     <!-- PWA manifest (optional) -->
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Optional: preconnect to your font/CDN origins
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/components/home/AlgoCard.tsx
+++ b/src/components/home/AlgoCard.tsx
@@ -16,10 +16,10 @@ function DifficultyPill({ v }: { v?: AlgoItem["difficulty"] }) {
     typeof v === "number" ? (v <= 2 ? "Easy" : v <= 3 ? "Medium" : "Hard") : v;
   const styles =
     label === "Easy"
-      ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300"
+      ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
       : label === "Medium"
-      ? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
-      : "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300";
+      ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200"
+      : "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-200";
   return (
     <span className={`px-2 py-0.5 rounded text-[11px] font-semibold ${styles}`}>
       {label}
@@ -112,7 +112,7 @@ export default function AlgoCard({
         {/* related shortcuts */}
         {item.related?.length ? (
           <div className="mt-3">
-            <div className="text-[11px] font-semibold text-slate-500 dark:text-slate-400 mb-1">
+            <div className="text-[11px] font-semibold text-slate-700 dark:text-slate-300 mb-1">
               Related
             </div>
             <div className="flex flex-wrap gap-1">

--- a/src/components/panels/AboutPanel.tsx
+++ b/src/components/panels/AboutPanel.tsx
@@ -75,7 +75,7 @@ export default function AboutPanel({ meta }: { meta: AlgoMeta }) {
             <table className="w-full text-sm border-collapse">
               <tbody>
                 <tr>
-                  <td className="text-slate-500 dark:text-slate-400 pr-4">
+                  <td className="text-slate-700 dark:text-slate-300 pr-4">
                     Best time
                   </td>
                   <td className="text-slate-900 dark:text-slate-100">
@@ -83,7 +83,7 @@ export default function AboutPanel({ meta }: { meta: AlgoMeta }) {
                   </td>
                 </tr>
                 <tr>
-                  <td className="text-slate-500 dark:text-slate-400 pr-4">
+                  <td className="text-slate-700 dark:text-slate-300 pr-4">
                     Average time
                   </td>
                   <td className="text-slate-900 dark:text-slate-100">
@@ -91,7 +91,7 @@ export default function AboutPanel({ meta }: { meta: AlgoMeta }) {
                   </td>
                 </tr>
                 <tr>
-                  <td className="text-slate-500 dark:text-slate-400 pr-4">
+                  <td className="text-slate-700 dark:text-slate-300 pr-4">
                     Worst time
                   </td>
                   <td className="text-slate-900 dark:text-slate-100">
@@ -99,7 +99,7 @@ export default function AboutPanel({ meta }: { meta: AlgoMeta }) {
                   </td>
                 </tr>
                 <tr>
-                  <td className="text-slate-500 dark:text-slate-400 pr-4">
+                  <td className="text-slate-700 dark:text-slate-300 pr-4">
                     Space
                   </td>
                   <td className="text-slate-900 dark:text-slate-100">
@@ -108,7 +108,7 @@ export default function AboutPanel({ meta }: { meta: AlgoMeta }) {
                 </tr>
                 {typeof c.stable === "boolean" && (
                   <tr>
-                    <td className="text-slate-500 dark:text-slate-400 pr-4">
+                    <td className="text-slate-700 dark:text-slate-300 pr-4">
                       Stable
                     </td>
                     <td className="text-slate-900 dark:text-slate-100">
@@ -118,7 +118,7 @@ export default function AboutPanel({ meta }: { meta: AlgoMeta }) {
                 )}
                 {typeof c.inPlace === "boolean" && (
                   <tr>
-                    <td className="text-slate-500 dark:text-slate-400 pr-4">
+                    <td className="text-slate-700 dark:text-slate-300 pr-4">
                       In-place
                     </td>
                     <td className="text-slate-900 dark:text-slate-100">
@@ -184,7 +184,7 @@ function AboutPanelContent({ meta }: { meta: AlgoMeta }) {
         <table className="w-full text-sm border-collapse">
           <tbody>
             <tr>
-              <td className="text-slate-500 dark:text-slate-400 pr-4">
+              <td className="text-slate-700 dark:text-slate-300 pr-4">
                 Best time
               </td>
               <td className="text-slate-900 dark:text-slate-100">
@@ -192,7 +192,7 @@ function AboutPanelContent({ meta }: { meta: AlgoMeta }) {
               </td>
             </tr>
             <tr>
-              <td className="text-slate-500 dark:text-slate-400 pr-4">
+              <td className="text-slate-700 dark:text-slate-300 pr-4">
                 Average time
               </td>
               <td className="text-slate-900 dark:text-slate-100">
@@ -200,7 +200,7 @@ function AboutPanelContent({ meta }: { meta: AlgoMeta }) {
               </td>
             </tr>
             <tr>
-              <td className="text-slate-500 dark:text-slate-400 pr-4">
+              <td className="text-slate-700 dark:text-slate-300 pr-4">
                 Worst time
               </td>
               <td className="text-slate-900 dark:text-slate-100">
@@ -208,12 +208,12 @@ function AboutPanelContent({ meta }: { meta: AlgoMeta }) {
               </td>
             </tr>
             <tr>
-              <td className="text-slate-500 dark:text-slate-400 pr-4">Space</td>
+              <td className="text-slate-700 dark:text-slate-300 pr-4">Space</td>
               <td className="text-slate-900 dark:text-slate-100">{c.space}</td>
             </tr>
             {typeof c.stable === "boolean" && (
               <tr>
-                <td className="text-slate-500 dark:text-slate-400 pr-4">
+                <td className="text-slate-700 dark:text-slate-300 pr-4">
                   Stable
                 </td>
                 <td className="text-slate-900 dark:text-slate-100">
@@ -223,7 +223,7 @@ function AboutPanelContent({ meta }: { meta: AlgoMeta }) {
             )}
             {typeof c.inPlace === "boolean" && (
               <tr>
-                <td className="text-slate-500 dark:text-slate-400 pr-4">
+                <td className="text-slate-700 dark:text-slate-300 pr-4">
                   In-place
                 </td>
                 <td className="text-slate-900 dark:text-slate-100">

--- a/src/components/panels/CodePanel.tsx
+++ b/src/components/panels/CodePanel.tsx
@@ -278,7 +278,7 @@ export default function CodePanel({
                     codeLine === i + 1 ? "active" : ""
                   } text-slate-900 dark:text-slate-200`}
                 >
-                  <span className="ln text-slate-400 dark:text-slate-500">
+                  <span className="ln text-slate-600 dark:text-slate-400">
                     {i + 1}
                   </span>
                   <span

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -12,10 +12,21 @@ export default function Markdown({ children }: { children: string }) {
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
-          h1: (p) => <h1 className="text-xl font-bold mt-2 mb-2" {...p} />,
-          h2: (p) => <h2 className="text-lg font-semibold mt-3 mb-2" {...p} />,
+          // Shift markdown headings down one level so pages retain a single
+          // top-level <h1> and maintain proper heading order for a11y.
+          h1: (p) => <h2 className="text-xl font-bold mt-2 mb-2" {...p} />,
+          h2: (p) => <h3 className="text-lg font-semibold mt-3 mb-2" {...p} />,
           h3: (p) => (
-            <h3 className="text-base font-semibold mt-3 mb-2" {...p} />
+            <h4 className="text-base font-semibold mt-3 mb-2" {...p} />
+          ),
+          h4: (p) => (
+            <h5 className="text-base font-semibold mt-3 mb-2" {...p} />
+          ),
+          h5: (p) => (
+            <h6 className="text-sm font-semibold mt-3 mb-2" {...p} />
+          ),
+          h6: (p) => (
+            <h6 className="text-sm font-semibold mt-3 mb-2" {...p} />
           ),
           p: (p) => <p className="leading-7 mb-2" {...p} />,
           ul: (p) => <ul className="list-disc pl-5 space-y-1 mb-2" {...p} />,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -291,7 +291,7 @@ export default function HomePage() {
       {tagUniverse.length ? (
         <div className="px-4 py-3 border-b bg-white/70 dark:bg-slate-900/60 dark:border-slate-800">
           <div className="max-w-7xl mx-auto flex flex-wrap items-center gap-2">
-            <div className="text-xs font-semibold text-slate-500 dark:text-slate-400 mr-2">
+            <div className="text-xs font-semibold text-slate-700 dark:text-slate-300 mr-2">
               Tags:
             </div>
             {tagUniverse.map((t) => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -157,7 +157,7 @@ h3 {
 @layer components {
   .ui-input {
     @apply w-full rounded-xl border px-3 py-2 shadow-sm
-           bg-white text-slate-900 border-slate-300 placeholder:text-slate-500
+           bg-white text-slate-900 border-slate-300 placeholder:text-slate-600
            focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
            dark:bg-slate-900 dark:text-slate-100 dark:border-slate-700 dark:placeholder:text-slate-400;
   }
@@ -170,7 +170,7 @@ h3 {
   /* NOTE: can't @apply .ui-input; @apply only accepts utilities */
   .ui-textarea {
     @apply w-full rounded-xl border px-3 py-2 shadow-sm
-           bg-white text-slate-900 border-slate-300 placeholder:text-slate-500
+           bg-white text-slate-900 border-slate-300 placeholder:text-slate-600
            focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
            dark:bg-slate-900 dark:text-slate-100 dark:border-slate-700 dark:placeholder:text-slate-400
            min-h-[92px];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    sourcemap: true,
+  },
 })


### PR DESCRIPTION
## Summary
- map Markdown headings down a level to maintain sequential order
- boost text contrast across UI and fix missing PWA manifest link
- enable source maps for builds to satisfy Lighthouse

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1d4ecb160832e8312eefbd47e1550